### PR TITLE
update card exp year to 2024

### DIFF
--- a/models/create-account-page.ts
+++ b/models/create-account-page.ts
@@ -193,7 +193,7 @@ export class CreateAccountPage {
 			await test.step('Enter Med Card Exp', async () => {
 				await this.medCardExpMonth.selectOption('12')
 				await this.medCardExpDay.selectOption('16')
-				await this.medCardExpYear.selectOption('2023')
+				await this.medCardExpYear.selectOption('2024')
 			})
 		}
 		if (state === 'FL') {
@@ -222,7 +222,7 @@ export class CreateAccountPage {
 
 				await this.medCardExpMonth.selectOption('12')
 				await this.medCardExpDay.selectOption('16')
-				await this.medCardExpYear.selectOption('2023')
+				await this.medCardExpYear.selectOption('2024')
 			})
 
 			await test.step('Complete Usage Type Form', async () => {
@@ -339,7 +339,7 @@ export class CreateAccountPage {
 			await test.step('Enter Med Card Exp', async () => {
 				await this.medCardExpMonth.selectOption('12')
 				await this.medCardExpDay.selectOption('16')
-				await this.medCardExpYear.selectOption('2023')
+				await this.medCardExpYear.selectOption('2024')
 			})
 			await test.step('Enter Med Card Number', async () => {
 				await this.medCardNumber.fill(medCardNumber)
@@ -367,7 +367,7 @@ export class CreateAccountPage {
 			await test.step('Enter DL Exp', async () => {
 				await this.driversLicenseExpMonth.selectOption('12')
 				await this.driversLicenseExpDay.selectOption('16')
-				await this.driversLicenseExpYear.selectOption('2023')
+				await this.driversLicenseExpYear.selectOption('2024')
 			})
 
 			await test.step('Enter DLNumber', async () => {
@@ -468,7 +468,7 @@ export class CreateAccountPage {
 			await test.step('Enter Med Card Exp', async () => {
 				await this.medCardExpMonth.selectOption('12')
 				await this.medCardExpDay.selectOption('16')
-				await this.medCardExpYear.selectOption('2023')
+				await this.medCardExpYear.selectOption('2024')
 			})
 		}
 
@@ -632,7 +632,7 @@ export class CreateAccountPage {
 			await test.step('Enter Med Card Exp', async () => {
 				await this.medCardExpMonth.selectOption('12')
 				await this.medCardExpDay.selectOption('16')
-				await this.medCardExpYear.selectOption('2023')
+				await this.medCardExpYear.selectOption('2024')
 			})
 			await test.step('Complete Usage Type Form', async () => {
 				await (await this.page.$('text=Register')).click()


### PR DESCRIPTION
tests are failing because the med card exp date being input is 2023 and we have now passed that date. so this updates it to 2024 so should work for the rest of the year