### PR TITLE
feat: add cart item count input to workflow dispatch for build valida…

### DIFF
--- a/.github/workflows/seventen-thelist-ca-prod-build-validation.yml
+++ b/.github/workflows/seventen-thelist-ca-prod-build-validation.yml
@@ -1,5 +1,23 @@
 name: List - CA - Prod - Build Validation
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cart_item_count:
+        description: Number of items to add to cart
+        required: true
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
 jobs:
   smoke-test-prod-ca:
     timeout-minutes: 60
@@ -8,6 +26,7 @@ jobs:
       ENV: prod-ca thelist.710labs.com
       ENV_ID: prod-ca
       EXECUTION_TYPE: ${{ github.event_name == 'workflow_dispatch' && 'Manual Run' || 'Scheduled Run' }}
+      SMOKE_CART_ITEM_COUNT: ${{ github.event.inputs.cart_item_count || '1' }}
       RUN_ID: ${{github.run_number}}
       UNIQUE_RUN_ID: ${{github.run_id}}
       ADMIN_USER: ${{ secrets.ADMIN_USER }}

--- a/.github/workflows/seventen-thelist-ca-prod-smoke-test.yml
+++ b/.github/workflows/seventen-thelist-ca-prod-smoke-test.yml
@@ -1,5 +1,23 @@
 name: List - CA - Prod - Smoke Test (old)
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cart_item_count:
+        description: Number of items to add to cart
+        required: true
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
 jobs:
   smoke-test-prod-ca:
     timeout-minutes: 60
@@ -8,6 +26,7 @@ jobs:
       ENV: prod-ca thelist.710labs.com
       ENV_ID: prod-ca
       EXECUTION_TYPE: ${{ github.event_name == 'workflow_dispatch' && 'Manual Run' || 'Scheduled Run' }}
+      SMOKE_CART_ITEM_COUNT: ${{ github.event.inputs.cart_item_count || '1' }}
       ADMIN_USER: ${{ secrets.ADMIN_USER }}
       ADMIN_PW: ${{ secrets.ADMIN_PW }}
       CHECKOUT_PASSWORD: ${{ secrets.CHECKOUT_PASSWORD }}

--- a/.github/workflows/seventen-thelist-co-prod-smoke-test.yml
+++ b/.github/workflows/seventen-thelist-co-prod-smoke-test.yml
@@ -48,7 +48,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET}}
     outputs:
       order-id: ${{ steps.extract.outputs.orderID }}
-      split-order-id: ${{ steps.extract-split.outputs.splitOrderID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -84,19 +83,6 @@ jobs:
             # still emit the output key, just blank
             echo "orderID=" >> $GITHUB_OUTPUT
           fi
-      - name: Read split_order_id.txt
-        if: always()
-        id: extract-split
-        run: |
-          if [[ -f split_order_id.txt ]]; then
-            SPLIT_ORDER_ID=$(<split_order_id.txt)
-            echo "✅ Found Split Order ID: $SPLIT_ORDER_ID"
-            echo "splitOrderID=$SPLIT_ORDER_ID" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️  split_order_id.txt not found; setting empty splitOrderID"
-            # still emit the output key, just blank
-            echo "splitOrderID=" >> $GITHUB_OUTPUT
-          fi
   cleanup:
     name: Cleanup Cancel Test Order
     needs: smoke-test-prod-co
@@ -115,15 +101,6 @@ jobs:
         run: |
           echo "🛠 Cancelling order ${{ needs.smoke-test-prod-co.outputs.order-id }}…"
           curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-co.outputs.order-id }}" \
-            -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
-            -H "Content-Type: application/json" \
-            -d '{"status":"cancelled"}'
-      - name: Cancel split order via WooCommerce API
-        # only call if we actually got an ID
-        if: ${{ needs.smoke-test-prod-co.outputs.split-order-id != '' }}
-        run: |
-          echo "🛠 Cancelling split order ${{ needs.smoke-test-prod-co.outputs.split-order-id }}…"
-          curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-co.outputs.split-order-id }}" \
             -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
             -H "Content-Type: application/json" \
             -d '{"status":"cancelled"}'

--- a/.github/workflows/seventen-thelist-co-prod-smoke-test.yml
+++ b/.github/workflows/seventen-thelist-co-prod-smoke-test.yml
@@ -1,5 +1,23 @@
 name: List - CO - Prod - Smoke Test
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cart_item_count:
+        description: Number of items to add to cart
+        required: true
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
 jobs:
   smoke-test-prod-co:
     timeout-minutes: 60
@@ -8,6 +26,7 @@ jobs:
       ENV: prod-co thelist-co.710labs.com
       ENV_ID: prod-co
       EXECUTION_TYPE: ${{ github.event_name == 'workflow_dispatch' && 'Manual Run' || 'Scheduled Run' }}
+      SMOKE_CART_ITEM_COUNT: ${{ github.event.inputs.cart_item_count || '1' }}
       RUN_ID: ${{github.run_number}}
       UNIQUE_RUN_ID: ${{github.run_id}}
       ADMIN_USER: ${{ secrets.ADMIN_USER }}

--- a/.github/workflows/seventen-thelist-fl-prod-build-validation.yml
+++ b/.github/workflows/seventen-thelist-fl-prod-build-validation.yml
@@ -29,7 +29,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET}}
     outputs:
       order-id: ${{ steps.extract.outputs.orderID }}
-      split-order-id: ${{ steps.extract-split.outputs.splitOrderID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -65,19 +64,6 @@ jobs:
             # still emit the output key, just blank
             echo "orderID=" >> $GITHUB_OUTPUT
           fi
-      - name: Read split_order_id.txt
-        if: always()
-        id: extract-split
-        run: |
-          if [[ -f split_order_id.txt ]]; then
-            SPLIT_ORDER_ID=$(<split_order_id.txt)
-            echo "✅ Found Split Order ID: $SPLIT_ORDER_ID"
-            echo "splitOrderID=$SPLIT_ORDER_ID" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️  split_order_id.txt not found; setting empty splitOrderID"
-            # still emit the output key, just blank
-            echo "splitOrderID=" >> $GITHUB_OUTPUT
-          fi
   cleanup:
     name: Cleanup Cancel Test Order
     needs: smoke-test-prod-fl
@@ -96,15 +82,6 @@ jobs:
         run: |
           echo "🛠 Cancelling order ${{ needs.smoke-test-prod-fl.outputs.order-id }}…"
           curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-fl.outputs.order-id }}" \
-            -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
-            -H "Content-Type: application/json" \
-            -d '{"status":"cancelled"}'
-      - name: Cancel split order via WooCommerce API
-        # only call if we actually got an ID
-        if: ${{ needs.smoke-test-prod-fl.outputs.split-order-id != '' }}
-        run: |
-          echo "🛠 Cancelling split order ${{ needs.smoke-test-prod-fl.outputs.split-order-id }}…"
-          curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-fl.outputs.split-order-id }}" \
             -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
             -H "Content-Type: application/json" \
             -d '{"status":"cancelled"}'

--- a/.github/workflows/seventen-thelist-fl-prod-smoke-test.yml
+++ b/.github/workflows/seventen-thelist-fl-prod-smoke-test.yml
@@ -31,6 +31,8 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET}}
       DEFAULT_VIDEO_PREVIEW_URL: https://tymber-s3.imgix.net/herbnjoy-beverly-hills-350/product-brand-63616/d17157b5-8a90-48b1-aeb6-d0e092351548.png?s=480dd20057b2bd21b3b6d6200a3c0679
 
+    outputs:
+      order-id: ${{ steps.extract.outputs.orderID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -46,8 +48,38 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npm run smoke:test:prod:fl
+      - name: Read order_id.txt
+        if: always()
+        id: extract
+        run: |
+          if [[ -f order_id.txt ]]; then
+            ORDER_ID=$(<order_id.txt)
+            echo "✅ Found Order ID: $ORDER_ID"
+            echo "orderID=$ORDER_ID" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️  order_id.txt not found; setting empty orderID"
+            echo "orderID=" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-report
           path: playwright-report/
+  cleanup:
+    name: Cleanup Cancel Test Order
+    needs: smoke-test-prod-fl
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      WC_CONSUMER_KEY: ${{ secrets.WOO_FL_PROD_KEY }}
+      WC_CONSUMER_SECRET: ${{ secrets.WOO_FL_PROD_SECRET }}
+      BASE_URL: ${{ secrets.BASE_URL_PROD_FL }}
+    steps:
+      - name: Cancel test order via WooCommerce API
+        if: ${{ needs.smoke-test-prod-fl.outputs.order-id != '' }}
+        run: |
+          echo "🛠 Cancelling order ${{ needs.smoke-test-prod-fl.outputs.order-id }}…"
+          curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-fl.outputs.order-id }}" \
+            -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d '{"status":"cancelled"}'

--- a/.github/workflows/seventen-thelist-mi-prod-build-validation.yml
+++ b/.github/workflows/seventen-thelist-mi-prod-build-validation.yml
@@ -48,7 +48,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET}}
     outputs:
       order-id: ${{ steps.extract.outputs.orderID }}
-      split-order-id: ${{ steps.extract-split.outputs.splitOrderID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -84,19 +83,6 @@ jobs:
             # still emit the output key, just blank
             echo "orderID=" >> $GITHUB_OUTPUT
           fi
-      - name: Read split_order_id.txt
-        if: always()
-        id: extract-split
-        run: |
-          if [[ -f split_order_id.txt ]]; then
-            SPLIT_ORDER_ID=$(<split_order_id.txt)
-            echo "✅ Found Split Order ID: $SPLIT_ORDER_ID"
-            echo "splitOrderID=$SPLIT_ORDER_ID" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️  split_order_id.txt not found; setting empty splitOrderID"
-            # still emit the output key, just blank
-            echo "splitOrderID=" >> $GITHUB_OUTPUT
-          fi
   cleanup:
     name: Cleanup Cancel Test Order
     needs: build-validation-prod-mi
@@ -115,15 +101,6 @@ jobs:
         run: |
           echo "🛠 Cancelling order ${{ needs.build-validation-prod-mi.outputs.order-id }}…"
           curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.build-validation-prod-mi.outputs.order-id }}" \
-            -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
-            -H "Content-Type: application/json" \
-            -d '{"status":"cancelled"}'
-      - name: Cancel split order via WooCommerce API
-        # only call if we actually got an ID
-        if: ${{ needs.build-validation-prod-mi.outputs.split-order-id != '' }}
-        run: |
-          echo "🛠 Cancelling split order ${{ needs.build-validation-prod-mi.outputs.split-order-id }}…"
-          curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.build-validation-prod-mi.outputs.split-order-id }}" \
             -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
             -H "Content-Type: application/json" \
             -d '{"status":"cancelled"}'

--- a/.github/workflows/seventen-thelist-mi-prod-build-validation.yml
+++ b/.github/workflows/seventen-thelist-mi-prod-build-validation.yml
@@ -1,5 +1,23 @@
 name: List - MI - Prod - Build Validation
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cart_item_count:
+        description: Number of items to add to cart
+        required: true
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
 jobs:
   build-validation-prod-mi:
     timeout-minutes: 60
@@ -8,6 +26,7 @@ jobs:
       ENV: prod-mi thelist-mi.710labs.com
       ENV_ID: prod-mi
       EXECUTION_TYPE: ${{ github.event_name == 'workflow_dispatch' && 'Manual Run' || 'Scheduled Run' }}
+      SMOKE_CART_ITEM_COUNT: ${{ github.event.inputs.cart_item_count || '1' }}
       RUN_ID: ${{github.run_number}}
       UNIQUE_RUN_ID: ${{github.run_id}}
       ADMIN_USER: ${{ secrets.ADMIN_USER }}

--- a/.github/workflows/seventen-thelist-mi-prod-smoke-test.yml
+++ b/.github/workflows/seventen-thelist-mi-prod-smoke-test.yml
@@ -46,6 +46,8 @@ jobs:
       S3_REGION: ${{ secrets.S3_REGION}}
       AWS_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY}}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET}}
+    outputs:
+      order-id: ${{ steps.extract.outputs.orderID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -61,8 +63,38 @@ jobs:
         run: npx playwright install --with-deps
       - name: Run Playwright tests
         run: npm run smoke:test:prod:mi
+      - name: Read order_id.txt
+        if: always()
+        id: extract
+        run: |
+          if [[ -f order_id.txt ]]; then
+            ORDER_ID=$(<order_id.txt)
+            echo "✅ Found Order ID: $ORDER_ID"
+            echo "orderID=$ORDER_ID" >> $GITHUB_OUTPUT
+          else
+            echo "⚠️  order_id.txt not found; setting empty orderID"
+            echo "orderID=" >> $GITHUB_OUTPUT
+          fi
       - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: playwright-report
           path: playwright-report/
+  cleanup:
+    name: Cleanup Cancel Test Order
+    needs: smoke-test-prod-mi
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      WC_CONSUMER_KEY: ${{ secrets.WOO_MI_PROD_KEY }}
+      WC_CONSUMER_SECRET: ${{ secrets.WOO_MI_PROD_SECRET }}
+      BASE_URL: ${{ secrets.BASE_URL_PROD_MI }}
+    steps:
+      - name: Cancel test order via WooCommerce API
+        if: ${{ needs.smoke-test-prod-mi.outputs.order-id != '' }}
+        run: |
+          echo "🛠 Cancelling order ${{ needs.smoke-test-prod-mi.outputs.order-id }}…"
+          curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-mi.outputs.order-id }}" \
+            -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
+            -H "Content-Type: application/json" \
+            -d '{"status":"cancelled"}'

--- a/.github/workflows/seventen-thelist-mi-prod-smoke-test.yml
+++ b/.github/workflows/seventen-thelist-mi-prod-smoke-test.yml
@@ -1,5 +1,23 @@
 name: List - MI - Prod - Smoke Test (old)
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cart_item_count:
+        description: Number of items to add to cart
+        required: true
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
 jobs:
   smoke-test-prod-mi:
     timeout-minutes: 60
@@ -8,6 +26,7 @@ jobs:
       ENV: prod-mi thelist-mi.710labs.com
       ENV_ID: prod-mi
       EXECUTION_TYPE: ${{ github.event_name == 'workflow_dispatch' && 'Manual Run' || 'Scheduled Run' }}
+      SMOKE_CART_ITEM_COUNT: ${{ github.event.inputs.cart_item_count || '1' }}
       RUN_ID: ${{github.run_number}}
       UNIQUE_RUN_ID: ${{github.run_id}}
       ADMIN_USER: ${{ secrets.ADMIN_USER }}

--- a/.github/workflows/seventen-thelist-nj-prod-build-validation.yml
+++ b/.github/workflows/seventen-thelist-nj-prod-build-validation.yml
@@ -48,7 +48,6 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET}}
     outputs:
       order-id: ${{ steps.extract.outputs.orderID }}
-      split-order-id: ${{ steps.extract-split.outputs.splitOrderID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -84,19 +83,6 @@ jobs:
             # still emit the output key, just blank
             echo "orderID=" >> $GITHUB_OUTPUT
           fi
-      - name: Read split_order_id.txt
-        if: always()
-        id: extract-split
-        run: |
-          if [[ -f split_order_id.txt ]]; then
-            SPLIT_ORDER_ID=$(<split_order_id.txt)
-            echo "✅ Found Split Order ID: $SPLIT_ORDER_ID"
-            echo "splitOrderID=$SPLIT_ORDER_ID" >> $GITHUB_OUTPUT
-          else
-            echo "⚠️  split_order_id.txt not found; setting empty splitOrderID"
-            # still emit the output key, just blank
-            echo "splitOrderID=" >> $GITHUB_OUTPUT
-          fi
   cleanup:
     name: Cleanup Cancel Test Order
     needs: smoke-test-prod-nj
@@ -115,15 +101,6 @@ jobs:
         run: |
           echo "🛠 Cancelling order ${{ needs.smoke-test-prod-nj.outputs.order-id }}…"
           curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-nj.outputs.order-id }}" \
-            -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
-            -H "Content-Type: application/json" \
-            -d '{"status":"cancelled"}'
-      - name: Cancel split order via WooCommerce API
-        # only call if we actually got an ID
-        if: ${{ needs.smoke-test-prod-nj.outputs.split-order-id != '' }}
-        run: |
-          echo "🛠 Cancelling split order ${{ needs.smoke-test-prod-nj.outputs.split-order-id }}…"
-          curl -X PUT "${BASE_URL}/wp-json/wc/v3/orders/${{ needs.smoke-test-prod-nj.outputs.split-order-id }}" \
             -u "${WC_CONSUMER_KEY}:${WC_CONSUMER_SECRET}" \
             -H "Content-Type: application/json" \
             -d '{"status":"cancelled"}'

--- a/.github/workflows/seventen-thelist-nj-prod-build-validation.yml
+++ b/.github/workflows/seventen-thelist-nj-prod-build-validation.yml
@@ -1,5 +1,23 @@
 name: List - NJ - Prod - Build Validation
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      cart_item_count:
+        description: Number of items to add to cart
+        required: true
+        default: '1'
+        type: choice
+        options:
+          - '1'
+          - '2'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '7'
+          - '8'
+          - '9'
+          - '10'
 jobs:
   smoke-test-prod-nj:
     timeout-minutes: 60
@@ -8,6 +26,7 @@ jobs:
       ENV: prod-nj thelist-nj.710labs.com
       ENV_ID: prod-nj
       EXECUTION_TYPE: ${{ github.event_name == 'workflow_dispatch' && 'Manual Run' || 'Scheduled Run' }}
+      SMOKE_CART_ITEM_COUNT: ${{ github.event.inputs.cart_item_count || '1' }}
       RUN_ID: ${{github.run_number}}
       UNIQUE_RUN_ID: ${{github.run_id}}
       ADMIN_USER: ${{ secrets.ADMIN_USER }}

--- a/models/order-recieved-page.ts
+++ b/models/order-recieved-page.ts
@@ -19,9 +19,14 @@ export class OrderReceivedPage {
 		this.orderNumber = this.page.locator('.woocommerce-order-overview__order >> strong')
 	}
 
+	private async waitForOrderReceivedPage() {
+		await expect(this.page).toHaveURL(/order-received/, { timeout: 30_000 })
+		await this.orderNumber.waitFor({ state: 'visible', timeout: 30_000 })
+	}
+
 	async confirmOrderDetail(orderInfo: any = null): Promise<any> {
 		var orderNumber
-		this.page.waitForNavigation()
+		await this.waitForOrderReceivedPage()
 		await test.step('Verify Layout', async () => {
 			await assertFooterLinks(this.page)
 		})
@@ -39,8 +44,7 @@ export class OrderReceivedPage {
 
 	async getOrderNumber(): Promise<any> {
 		var orderNumber
-		this.page.waitForNavigation()
-		await this.orderNumber.waitFor({ state: 'visible' })
+		await this.waitForOrderReceivedPage()
 		orderNumber = await this.orderNumber.innerText()
 		return orderNumber
 	}

--- a/tests/smoke-tests/smoke-test-ca.spec.ts
+++ b/tests/smoke-tests/smoke-test-ca.spec.ts
@@ -8,10 +8,11 @@ import { CartPage } from '../../models/cart-page'
 import { OrderReceivedPage } from '../../models/order-recieved-page'
 import { faker } from '@faker-js/faker'
 import { appendFileSync, writeFileSync } from 'fs'
+import { getSmokeCartItemCount } from '../../utils/smoke-cart-item-count'
 
 test.describe('Basic Acceptance Tests CA', () => {
 	const zipCode = '90210'
-	const orderQuanity = 2
+	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
 	var cartTotals: any
 
@@ -61,7 +62,7 @@ test.describe('Basic Acceptance Tests CA', () => {
 		})
 
 		await test.step('Add Products to Cart', async () => {
-			await shopPage.addProductsToCart(orderQuanity, mobile, 'Delivery', 'recreational', {
+			await shopPage.addProductsToCart(cartItemCount, mobile, 'Delivery', 'recreational', {
 				exactItemCount: true,
 			})
 			cartTotals = await cartPage.verifyCart(zipCode)

--- a/tests/smoke-tests/smoke-test-co.spec.ts
+++ b/tests/smoke-tests/smoke-test-co.spec.ts
@@ -5,10 +5,7 @@ import { ShopPage } from '../../models/shop-page'
 import { CreateAccountPage } from '../../models/create-account-page'
 import { CheckoutPage } from '../../models/checkout-page'
 import { CartPage } from '../../models/cart-page'
-import { MyAccountPage } from '../../models/my-account-page'
-import { AdminLogin } from '../../models/admin/admin-login-page'
 import { OrderReceivedPage } from '../../models/order-recieved-page'
-import { EditOrderPage } from '../../models/admin/edit-order-page'
 import { v4 as uuidv4 } from 'uuid'
 import { faker } from '@faker-js/faker'
 import { coloradoAddressess } from '../../utils/data-generator'
@@ -19,7 +16,6 @@ import { getSmokeCartItemCount } from '../../utils/smoke-cart-item-count'
 test.describe('Basic Acceptance Tests CO', () => {
 	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
-	var splitOrderNumber = ''
 	var cartTotals: any
 
 	test(`Basic Acceptance Test - Medical @medical @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -41,12 +37,9 @@ test.describe('Basic Acceptance Tests CO', () => {
 		const ageGatePage = new AgeGatePage(page)
 		const listPassword = new ListPasswordPage(page)
 		const createAccountPage = new CreateAccountPage(page, qaClient)
-		const myAccountPage = new MyAccountPage(page)
 		const shopPage = new ShopPage(page, browserName, workerInfo)
 		const cartPage = new CartPage(page, qaClient, browserName, workerInfo, 'medical')
 		const checkOutPage = new CheckoutPage(page, qaClient)
-		const adminLoginPage = new AdminLogin(page)
-		const editOrderPage = new EditOrderPage(page)
 		const orderReceived = new OrderReceivedPage(page)
 		var mobile = workerInfo.project.name === 'Mobile Chrome' ? true : false
 
@@ -89,30 +82,6 @@ test.describe('Basic Acceptance Tests CO', () => {
 			//write order number to file to use for cancel order via API
 			writeFileSync('order_id.txt', String(orderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote order_id.txt → ${orderNumber}`)
-		})
-		await test.step('Logout Consumer', async () => {
-			await myAccountPage.logout()
-		})
-
-		await test.step('Login Admin', async () => {
-			await adminLoginPage.login()
-		})
-		await test.step('Admin Split Order', async () => {
-			if (cartItemCount <= 1) {
-				console.log(`Skipping split order because SMOKE_CART_ITEM_COUNT=${cartItemCount}`)
-				return
-			}
-
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, cartItemCount)
-			//write split order number to file to use for cancel order via API
-			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
-			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
-		})
-		await test.step('Cancel Order', async () => {
-			await editOrderPage.cancelOrder(orderNumber)
-			if (splitOrderNumber) {
-				await editOrderPage.cancelOrder(splitOrderNumber)
-			}
 		})
 	})
 

--- a/tests/smoke-tests/smoke-test-co.spec.ts
+++ b/tests/smoke-tests/smoke-test-co.spec.ts
@@ -14,11 +14,12 @@ import { faker } from '@faker-js/faker'
 import { coloradoAddressess } from '../../utils/data-generator'
 import { fictionalAreacodes } from '../../utils/data-generator'
 import { writeFileSync } from 'fs'
+import { getSmokeCartItemCount } from '../../utils/smoke-cart-item-count'
 
 test.describe('Basic Acceptance Tests CO', () => {
-	const orderQuanity = 2
+	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
-	var splitOrderNumber: string
+	var splitOrderNumber = ''
 	var cartTotals: any
 
 	test(`Basic Acceptance Test - Medical @medical @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -72,7 +73,9 @@ test.describe('Basic Acceptance Tests CO', () => {
 		})
 
 		await test.step('Add Products to Cart', async () => {
-			await shopPage.addProductsToCart(orderQuanity, mobile, 'Pickup', 'medical')
+			await shopPage.addProductsToCart(cartItemCount, mobile, 'Pickup', 'medical', {
+				exactItemCount: true,
+			})
 			cartTotals = await cartPage.verifyCart(address.zipcode)
 		})
 
@@ -95,14 +98,21 @@ test.describe('Basic Acceptance Tests CO', () => {
 			await adminLoginPage.login()
 		})
 		await test.step('Admin Split Order', async () => {
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, orderQuanity)
+			if (cartItemCount <= 1) {
+				console.log(`Skipping split order because SMOKE_CART_ITEM_COUNT=${cartItemCount}`)
+				return
+			}
+
+			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, cartItemCount)
 			//write split order number to file to use for cancel order via API
 			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
 		})
 		await test.step('Cancel Order', async () => {
 			await editOrderPage.cancelOrder(orderNumber)
-			await editOrderPage.cancelOrder(splitOrderNumber)
+			if (splitOrderNumber) {
+				await editOrderPage.cancelOrder(splitOrderNumber)
+			}
 		})
 	})
 

--- a/tests/smoke-tests/smoke-test-fl.spec.ts
+++ b/tests/smoke-tests/smoke-test-fl.spec.ts
@@ -6,9 +6,6 @@ import { CreateAccountPage } from '../../models/create-account-page'
 import { v4 as uuidv4 } from 'uuid'
 import { CheckoutPage } from '../../models/checkout-page'
 import { CartPage } from '../../models/cart-page'
-import { MyAccountPage } from '../../models/my-account-page'
-import { AdminLogin } from '../../models/admin/admin-login-page'
-import { EditOrderPage } from '../../models/admin/edit-order-page'
 import { OrderReceivedPage } from '../../models/order-recieved-page'
 import { faker } from '@faker-js/faker'
 import { writeFileSync } from 'fs'
@@ -16,7 +13,6 @@ import { writeFileSync } from 'fs'
 test.describe('Medical Customer Checkout Florida', () => {
 	var cartTotals: any
 	var orderNumber: any
-	var splitOrderNumber: string
 	const orderQuanity = 6
 
 	test(`Basic Acceptance Test @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -38,12 +34,9 @@ test.describe('Medical Customer Checkout Florida', () => {
 		const ageGatePage = new AgeGatePage(page)
 		const listPassword = new ListPasswordPage(page)
 		const createAccountPage = new CreateAccountPage(page, qaClient)
-		const myAccountPage = new MyAccountPage(page)
 		const shopPage = new ShopPage(page, browserName, workerInfo)
 		const cartPage = new CartPage(page, qaClient, browserName, workerInfo, 'medical')
 		const checkOutPage = new CheckoutPage(page, qaClient)
-		const adminLoginPage = new AdminLogin(page)
-		const editOrderPage = new EditOrderPage(page)
 		const orderReceived = new OrderReceivedPage(page)
 		var mobile = workerInfo.project.name === 'Mobile Chrome' ? true : false
 
@@ -84,23 +77,6 @@ test.describe('Medical Customer Checkout Florida', () => {
 			//write order number to file to use for cancel order via API
 			writeFileSync('order_id.txt', String(orderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote order_id.txt → ${orderNumber}`)
-		})
-		await test.step('Logout Consumer', async () => {
-			await myAccountPage.logout()
-		})
-
-		await test.step('Login Admin', async () => {
-			await adminLoginPage.login()
-		})
-		await test.step('Admin Split Order', async () => {
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, orderQuanity)
-			//write split order number to file to use for cancel order via API
-			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
-			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
-		})
-		await test.step('Cancel Order', async () => {
-			await editOrderPage.cancelOrder(orderNumber)
-			await editOrderPage.cancelOrder(splitOrderNumber)
 		})
 	})
 })

--- a/tests/smoke-tests/smoke-test-mi.spec.ts
+++ b/tests/smoke-tests/smoke-test-mi.spec.ts
@@ -22,7 +22,7 @@ test.describe('Basic Acceptance Tests MI', () => {
 	var splitOrderNumber = ''
 	var cartTotals: any
 
-	test(`Basic Acceptance Test - Medical @medical @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
+	test(`Basic Acceptance Test - Recreational @recreational @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
 		test.skip(workerInfo.project.name === 'Mobile Chrome')
 		await context.addCookies([
 			{
@@ -43,7 +43,7 @@ test.describe('Basic Acceptance Tests MI', () => {
 		const createAccountPage = new CreateAccountPage(page, qaClient)
 		const myAccountPage = new MyAccountPage(page)
 		const shopPage = new ShopPage(page, browserName, workerInfo)
-		const cartPage = new CartPage(page, qaClient, browserName, workerInfo, 'medical')
+		const cartPage = new CartPage(page, qaClient, browserName, workerInfo, 'recreational')
 		const checkOutPage = new CheckoutPage(page, qaClient)
 		const adminLoginPage = new AdminLogin(page)
 		const editOrderPage = new EditOrderPage(page)
@@ -68,7 +68,7 @@ test.describe('Basic Acceptance Tests MI', () => {
 				faker.datatype.number({ min: 10, max: 12 }),
 				faker.datatype.number({ min: 1975, max: 2001 }),
 				faker.phone.phoneNumber('555-###-####'),
-				'medical',
+				'recreational',
 				address,
 				faker.datatype.number({ min: 11111111, max: 99999999 }).toString(),
 				faker.datatype.number({ min: 11111111, max: 99999999 }).toString(),
@@ -76,7 +76,7 @@ test.describe('Basic Acceptance Tests MI', () => {
 		})
 
 		await test.step(`Load Shopping Cart`, async () => {
-			await shopPage.addProductsToCart(cartItemCount, false, 'Pickup', 'medical', {
+			await shopPage.addProductsToCart(cartItemCount, false, 'Pickup', 'recreational', {
 				exactItemCount: true,
 			})
 		})

--- a/tests/smoke-tests/smoke-test-mi.spec.ts
+++ b/tests/smoke-tests/smoke-test-mi.spec.ts
@@ -5,10 +5,7 @@ import { ShopPage } from '../../models/shop-page'
 import { CreateAccountPage } from '../../models/create-account-page'
 import { CheckoutPage } from '../../models/checkout-page'
 import { CartPage } from '../../models/cart-page'
-import { MyAccountPage } from '../../models/my-account-page'
-import { AdminLogin } from '../../models/admin/admin-login-page'
 import { OrderReceivedPage } from '../../models/order-recieved-page'
-import { EditOrderPage } from '../../models/admin/edit-order-page'
 import { v4 as uuidv4 } from 'uuid'
 import { faker } from '@faker-js/faker'
 import { fictionalAreacodes } from '../../utils/data-generator'
@@ -19,7 +16,6 @@ test.describe('Basic Acceptance Tests MI', () => {
 	const zipCode = '48203'
 	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
-	var splitOrderNumber = ''
 	var cartTotals: any
 
 	test(`Basic Acceptance Test - Recreational @recreational @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -41,12 +37,9 @@ test.describe('Basic Acceptance Tests MI', () => {
 		const ageGatePage = new AgeGatePage(page)
 		const listPassword = new ListPasswordPage(page)
 		const createAccountPage = new CreateAccountPage(page, qaClient)
-		const myAccountPage = new MyAccountPage(page)
 		const shopPage = new ShopPage(page, browserName, workerInfo)
 		const cartPage = new CartPage(page, qaClient, browserName, workerInfo, 'recreational')
 		const checkOutPage = new CheckoutPage(page, qaClient)
-		const adminLoginPage = new AdminLogin(page)
-		const editOrderPage = new EditOrderPage(page)
 		const orderReceived = new OrderReceivedPage(page)
 		var mobile = workerInfo.project.name === 'Mobile Chrome' ? true : false
 
@@ -105,30 +98,6 @@ test.describe('Basic Acceptance Tests MI', () => {
 			//write order number to file to use for cancel order via API
 			writeFileSync('order_id.txt', String(orderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote order_id.txt → ${orderNumber}`)
-		})
-		await test.step('Logout Consumer', async () => {
-			await myAccountPage.logout()
-		})
-
-		await test.step('Login Admin', async () => {
-			await adminLoginPage.login()
-		})
-		await test.step('Admin Split Order', async () => {
-			if (cartItemCount <= 1) {
-				console.log(`Skipping split order because SMOKE_CART_ITEM_COUNT=${cartItemCount}`)
-				return
-			}
-
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, cartItemCount)
-			//write split order number to file to use for cancel order via API
-			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
-			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
-		})
-		await test.step('Cancel Order', async () => {
-			await editOrderPage.cancelOrder(orderNumber)
-			if (splitOrderNumber) {
-				await editOrderPage.cancelOrder(splitOrderNumber)
-			}
 		})
 	})
 })

--- a/tests/smoke-tests/smoke-test-mi.spec.ts
+++ b/tests/smoke-tests/smoke-test-mi.spec.ts
@@ -13,12 +13,13 @@ import { v4 as uuidv4 } from 'uuid'
 import { faker } from '@faker-js/faker'
 import { fictionalAreacodes } from '../../utils/data-generator'
 import { writeFileSync } from 'fs'
+import { getSmokeCartItemCount } from '../../utils/smoke-cart-item-count'
 
 test.describe('Basic Acceptance Tests MI', () => {
 	const zipCode = '48203'
-	const orderQuanity = 2
+	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
-	var splitOrderNumber: string
+	var splitOrderNumber = ''
 	var cartTotals: any
 
 	test(`Basic Acceptance Test - Medical @medical @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -75,7 +76,9 @@ test.describe('Basic Acceptance Tests MI', () => {
 		})
 
 		await test.step(`Load Shopping Cart`, async () => {
-			await shopPage.addProductsToCart(4, false, 'Pickup', 'medical')
+			await shopPage.addProductsToCart(cartItemCount, false, 'Pickup', 'medical', {
+				exactItemCount: true,
+			})
 		})
 
 		await test.step(`Navigate to Cart`, async () => {
@@ -111,14 +114,21 @@ test.describe('Basic Acceptance Tests MI', () => {
 			await adminLoginPage.login()
 		})
 		await test.step('Admin Split Order', async () => {
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, orderQuanity)
+			if (cartItemCount <= 1) {
+				console.log(`Skipping split order because SMOKE_CART_ITEM_COUNT=${cartItemCount}`)
+				return
+			}
+
+			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, cartItemCount)
 			//write split order number to file to use for cancel order via API
 			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
 		})
 		await test.step('Cancel Order', async () => {
 			await editOrderPage.cancelOrder(orderNumber)
-			await editOrderPage.cancelOrder(splitOrderNumber)
+			if (splitOrderNumber) {
+				await editOrderPage.cancelOrder(splitOrderNumber)
+			}
 		})
 	})
 })

--- a/tests/smoke-tests/smoke-test-nj.spec.ts
+++ b/tests/smoke-tests/smoke-test-nj.spec.ts
@@ -5,10 +5,7 @@ import { ShopPage } from '../../models/shop-page'
 import { CreateAccountPage } from '../../models/create-account-page'
 import { CheckoutPage } from '../../models/checkout-page'
 import { CartPage } from '../../models/cart-page'
-import { MyAccountPage } from '../../models/my-account-page'
-import { AdminLogin } from '../../models/admin/admin-login-page'
 import { OrderReceivedPage } from '../../models/order-recieved-page'
-import { EditOrderPage } from '../../models/admin/edit-order-page'
 import { v4 as uuidv4 } from 'uuid'
 import { faker } from '@faker-js/faker'
 import { writeFileSync } from 'fs'
@@ -19,7 +16,6 @@ test.describe('Basic Acceptance Tests NJ @smoke', () => {
 	const zipCode = '07901'
 	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
-	var splitOrderNumber = ''
 	var cartTotals: any
 
 	test(`Basic Acceptance Test - Medical @medical @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -41,12 +37,9 @@ test.describe('Basic Acceptance Tests NJ @smoke', () => {
 		const ageGatePage = new AgeGatePage(page)
 		const listPassword = new ListPasswordPage(page)
 		const createAccountPage = new CreateAccountPage(page, qaClient)
-		const myAccountPage = new MyAccountPage(page)
 		const shopPage = new ShopPage(page, browserName, workerInfo)
 		const cartPage = new CartPage(page, qaClient, browserName, workerInfo, 'medical')
 		const checkOutPage = new CheckoutPage(page, qaClient)
-		const adminLoginPage = new AdminLogin(page)
-		const editOrderPage = new EditOrderPage(page)
 		const orderReceived = new OrderReceivedPage(page)
 		var mobile = workerInfo.project.name === 'Mobile Chrome' ? true : false
 
@@ -89,30 +82,6 @@ test.describe('Basic Acceptance Tests NJ @smoke', () => {
 			//write order number to file to use for cancel order via API
 			writeFileSync('order_id.txt', String(orderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote order_id.txt → ${orderNumber}`)
-		})
-		await test.step('Logout Consumer', async () => {
-			await myAccountPage.logout()
-		})
-
-		await test.step('Login Admin', async () => {
-			await adminLoginPage.login()
-		})
-		await test.step('Admin Split Order', async () => {
-			if (cartItemCount <= 1) {
-				console.log(`Skipping split order because SMOKE_CART_ITEM_COUNT=${cartItemCount}`)
-				return
-			}
-
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, cartItemCount)
-			//write split order number to file to use for cancel order via API
-			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
-			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
-		})
-		await test.step('Cancel Order', async () => {
-			await editOrderPage.cancelOrder(orderNumber)
-			if (splitOrderNumber) {
-				await editOrderPage.cancelOrder(splitOrderNumber)
-			}
 		})
 	})
 })

--- a/tests/smoke-tests/smoke-test-nj.spec.ts
+++ b/tests/smoke-tests/smoke-test-nj.spec.ts
@@ -13,12 +13,13 @@ import { v4 as uuidv4 } from 'uuid'
 import { faker } from '@faker-js/faker'
 import { writeFileSync } from 'fs'
 import { fictionalAreacodes } from '../../utils/data-generator'
+import { getSmokeCartItemCount } from '../../utils/smoke-cart-item-count'
 
 test.describe('Basic Acceptance Tests NJ @smoke', () => {
 	const zipCode = '07901'
-	const orderQuanity = 2
+	const cartItemCount = getSmokeCartItemCount()
 	var orderNumber: any
-	var splitOrderNumber: string
+	var splitOrderNumber = ''
 	var cartTotals: any
 
 	test(`Basic Acceptance Test - Medical @medical @smoke`, async ({ page, browserName, context, qaClient }, workerInfo) => {
@@ -72,7 +73,9 @@ test.describe('Basic Acceptance Tests NJ @smoke', () => {
 		})
 
 		await test.step('Add Products to Cart', async () => {
-			await shopPage.addProductsToCart(orderQuanity, mobile, 'Pickup', 'medical')
+			await shopPage.addProductsToCart(cartItemCount, mobile, 'Pickup', 'medical', {
+				exactItemCount: true,
+			})
 			cartTotals = await cartPage.verifyCart(zipCode)
 		})
 
@@ -95,14 +98,21 @@ test.describe('Basic Acceptance Tests NJ @smoke', () => {
 			await adminLoginPage.login()
 		})
 		await test.step('Admin Split Order', async () => {
-			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, orderQuanity)
+			if (cartItemCount <= 1) {
+				console.log(`Skipping split order because SMOKE_CART_ITEM_COUNT=${cartItemCount}`)
+				return
+			}
+
+			splitOrderNumber = await editOrderPage.splitOrder(orderNumber, cartItemCount)
 			//write split order number to file to use for cancel order via API
 			writeFileSync('split_order_id.txt', String(splitOrderNumber), { encoding: 'utf-8' })
 			console.log(`✅ Wrote split_order_id.txt → ${splitOrderNumber}`)
 		})
 		await test.step('Cancel Order', async () => {
 			await editOrderPage.cancelOrder(orderNumber)
-			await editOrderPage.cancelOrder(splitOrderNumber)
+			if (splitOrderNumber) {
+				await editOrderPage.cancelOrder(splitOrderNumber)
+			}
 		})
 	})
 })

--- a/utils/smoke-cart-item-count.ts
+++ b/utils/smoke-cart-item-count.ts
@@ -1,0 +1,26 @@
+const smokeCartItemCountEnv = 'SMOKE_CART_ITEM_COUNT'
+const defaultSmokeCartItemCount = 1
+const minSmokeCartItemCount = 1
+const maxSmokeCartItemCount = 10
+
+export function getSmokeCartItemCount() {
+	const configuredValue = process.env[smokeCartItemCountEnv]?.trim()
+
+	if (!configuredValue) {
+		return defaultSmokeCartItemCount
+	}
+
+	const itemCount = Number(configuredValue)
+
+	if (
+		!Number.isInteger(itemCount) ||
+		itemCount < minSmokeCartItemCount ||
+		itemCount > maxSmokeCartItemCount
+	) {
+		throw new Error(
+			`${smokeCartItemCountEnv} must be an integer from ${minSmokeCartItemCount} to ${maxSmokeCartItemCount}. Received "${configuredValue}".`,
+		)
+	}
+
+	return itemCount
+}


### PR DESCRIPTION
…tion and smoke test workflows

- Updated multiple workflow files to include a new input for `cart_item_count`, allowing users to specify the number of items to add to the cart during manual runs.
- Introduced a utility function to retrieve and validate the cart item count, ensuring it falls within the specified range of 1 to 10.
- Adjusted test scripts to utilize the new cart item count input for adding products to the cart and handling order splitting.